### PR TITLE
Fix decimal number conversion

### DIFF
--- a/lib/kaiser_ruby/rockstar_transform.rb
+++ b/lib/kaiser_ruby/rockstar_transform.rb
@@ -33,10 +33,10 @@ module KaiserRuby
     rule(string_as_number: simple(:str)) do |context|
       if context[:str].to_s.include?('.')
         context[:str].to_s.gsub(/[^A-Za-z\s\.]/, '').split('.').map do |sub|
-          str_to_num(sub)
+          str_to_num(sub.strip)
         end.join('.').to_f
       else
-        str_to_num(context[:str])
+        str_to_num(context[:str]).to_i
       end
     end
 
@@ -218,7 +218,7 @@ module KaiserRuby
     end
 
     def self.str_to_num(string)
-      string.to_s.split(/\s+/).map { |e| e.length % 10 }.join.to_i
+      string.to_s.split(/\s+/).map { |e| e.length % 10 }.join
     end
   end
 end

--- a/spec/poetic_spec.rb
+++ b/spec/poetic_spec.rb
@@ -31,5 +31,9 @@ RSpec.describe KaiserRuby do
     it 'ignores apostrophes and other nonalpha chars' do
       expect(KaiserRuby.transpile("My dreams were ice. A life unfulfilled; wakin' everybody up, taking booze and pills")).to eq "my_dreams = 3.1415926535"
     end
+
+    it 'converts floats properly' do
+      expect(KaiserRuby.transpile("Conversion is lovestruck. lovestruck and essential seasick")).to eq "conversion = 0.0397"
+    end
   end
 end


### PR DESCRIPTION
"Conversion is lovestruck. lovestruck and essential seasick" should result in "conversion = 0.0397", so the .to_i should be moved away from the sub_to_num method to preserve the leading 0. Also strip the substring after splitting on the dot, so there aren't two leading zeroes.

Fixes #3