### PR TITLE
Fix small error involving version number in cli.rb

### DIFF
--- a/lib/kaiser_ruby/cli.rb
+++ b/lib/kaiser_ruby/cli.rb
@@ -1,4 +1,5 @@
 require 'thor'
+require_relative 'version'
 
 module KaiserRuby
   class CLI < Thor


### PR DESCRIPTION
Fixes an issue in which Kaiser will not run due to VERSION being undefined in cli.rb